### PR TITLE
Docs - Fix MkDocs emoji configuration error

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,19 +104,18 @@ markdown_extensions:
   - pymdownx.snippets
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
-  - attr_list
-  - md_in_html
-  - pymdownx.tabbed: # Extension for content tabs (=== "title")
-      alternate_style: true
-  - pymdownx.emoji: # Extension for icons
-      emoji_index: material.extensions.emoji.twemoji
-      emoji_generator: material.extensions.emoji.to_svg
-  - pymdownx.superfences: # Configuration block for Mermaid
+  - pymdownx.superfences:
       custom_fences:
         - name: mermaid
           class: mermaid
           format: pymdownx.superfences.fence_code_format
+  - attr_list
+  - md_in_html
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: pymdownx.emoji.twemoji
+      emoji_generator: pymdownx.emoji.to_svg
 
 extra_css:
   - stylesheets/custom.css


### PR DESCRIPTION
## Fix MkDocs emoji configuration error

**Problem**: MkDocs build failing with `TypeError: unsupported callable` when processing emoji extension.

**Solution**: Switch from `material.extensions.emoji` to `pymdownx.emoji` for emoji handling.

**Changes**:
- Updated `mkdocs.yml` emoji configuration to use pymdownx extension
- Consolidated duplicate `pymdownx.superfences` entries

Fixes the documentation build pipeline.